### PR TITLE
Type the message

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "protobuf-js-from-object";
 
 import * as jspb from "google-protobuf";
-export declare function serializeFromObject(
-  msg: any,
+export declare function serializeFromObject<T>(
+  msg: T.AsObject,
   ProtoClass: typeof jspb.Message
 ): Uint8Array;


### PR DESCRIPTION
Using a generic, it looks to be possible to get proper typing on the `msg`.

```ts
const buffer: Uint8Array = serializeFromObject<SomeProtoClass>(obj, SomeProtoClass);
```
where `obj` is now the `SomeProtoClass.AsObject` type